### PR TITLE
meson.build: fix missing license info in meson project declaration

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -19,6 +19,7 @@ project(
     'kconfig',
     meson_version: '>=1.4.0',
     version : run_command('support/meson/version.sh', 'get-vcs', check: true).stdout().strip(),
+    license: 'Apache-2.0',
     license_files: ['LICENSES/Apache-2.0.txt'],
 )
 


### PR DESCRIPTION
removed by mistake in previous PR ...